### PR TITLE
fix: move cursor to end of line when decrease shift

### DIFF
--- a/src/features/shiftHeading/operation.ts
+++ b/src/features/shiftHeading/operation.ts
@@ -99,6 +99,9 @@ export class DecreaseHeading implements EditorOperation {
 			return true;
 		}
 
+		const isOneline =
+			editor.getCursor("from").line === editor.getCursor("to").line;
+
 		// Dispatch Transaction
 		const editorChange = composeLineChanges(
 			editor,
@@ -109,6 +112,11 @@ export class DecreaseHeading implements EditorOperation {
 		editor.transaction({
 			changes: editorChange,
 		});
+
+		// If only one line is targeted, move the cursor to the end of the line.
+		if (isOneline) {
+			editor.setCursor(editor.getCursor("anchor").line);
+		}
 		return editorChange.length ? true : false;
 	};
 


### PR DESCRIPTION
ommitted by 930d096c05b62d96af03ff1011450992431b7751 (#21)
