### PR TITLE
Minor bug fixes(1.9.1)

### DIFF
--- a/src/features/applyHeading/module.ts
+++ b/src/features/applyHeading/module.ts
@@ -72,13 +72,5 @@ export const applyHeading = (
 		? `${bulletMarkers}${headingMarkers}`
 		: headingMarkers;
 
-	console.log({
-		principleText,
-		leadingMarkersRegExp,
-		chunk,
-		m: removed.match(leadingMarkersRegExp),
-		removed,
-	});
-
 	return leadingMarkers + principleText;
 };

--- a/src/features/applyHeading/module.ts
+++ b/src/features/applyHeading/module.ts
@@ -28,7 +28,8 @@ export const applyHeading = (
 		});
 	};
 
-	const isBullet = settings?.autoIndentBulletedHeader && /^\s*[-] /.test(chunk);
+	const isBullet =
+		settings?.syncHeadingsAndListsLevel && /^\s*[-] /.test(chunk);
 
 	let removed = chunk;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,7 +18,7 @@ export type HeadingShifterSettings = {
 			alt: boolean;
 		};
 	};
-	autoIndentBulletedHeader: boolean;
+	syncHeadingsAndListsLevel: boolean;
 };
 
 export const DEFAULT_SETTINGS: HeadingShifterSettings = {
@@ -37,7 +37,7 @@ export const DEFAULT_SETTINGS: HeadingShifterSettings = {
 			alt: false,
 		},
 	},
-	autoIndentBulletedHeader: false,
+	syncHeadingsAndListsLevel: false,
 };
 
 export class HeadingShifterSettingTab extends PluginSettingTab {
@@ -92,13 +92,13 @@ export class HeadingShifterSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Synchronization `Heading` and `Bulleted list indentation`")
 			.setDesc(
-				"When a header is applied to bulleted list, indent the line according to the header level.",
+				"When a headings is applied to bulleted list, indent the line according to the headings level.",
 			)
 			.addToggle((toggle) => {
 				toggle
-					.setValue(this.plugin.settings.autoIndentBulletedHeader)
+					.setValue(this.plugin.settings.syncHeadingsAndListsLevel)
 					.onChange((v) => {
-						this.plugin.settings.autoIndentBulletedHeader = v;
+						this.plugin.settings.syncHeadingsAndListsLevel = v;
 						this.plugin.saveSettings();
 					});
 			});

--- a/src/utils/editorChange.ts
+++ b/src/utils/editorChange.ts
@@ -39,7 +39,8 @@ export const execOutdent = (
 	editor: MinimumEditor,
 	settings: HeadingShifterSettings,
 ) => {
-	if (!settings.autoOutdent.enable || settings.autoIndentBulletedHeader) return;
+	if (!settings.autoOutdent.enable || settings.syncHeadingsAndListsLevel)
+		return;
 
 	// save current selection
 	const currentSelection = {

--- a/src/utils/editorChange.ts
+++ b/src/utils/editorChange.ts
@@ -39,7 +39,7 @@ export const execOutdent = (
 	editor: MinimumEditor,
 	settings: HeadingShifterSettings,
 ) => {
-	if (!settings.autoOutdent.enable) return;
+	if (!settings.autoOutdent.enable || settings.autoIndentBulletedHeader) return;
 
 	// save current selection
 	const currentSelection = {
@@ -69,10 +69,6 @@ export const execOutdent = (
 
 	// check need again
 	const lineNumbersAfter = getNeedsOutdentLines(startLineNumber, editor);
-	if (JSON.stringify(lineNumbers) === JSON.stringify(lineNumbersAfter)) {
-		editor.setSelection(currentSelection.anchor, currentSelection.head);
-		return;
-	}
 	if (lineNumbersAfter.length === 0) {
 		editor.setSelection(currentSelection.anchor, currentSelection.head);
 		return;

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -111,7 +111,7 @@ export const removeUsingRegexpStrings = (
 
 	// beginning
 	for (const regExpStr of regExpStrings.beginning ?? []) {
-		const regExp = new RegExp(`^${regExpStr}(.*)`);
+		const regExp = new RegExp(`^\\s*${regExpStr}(.*)`);
 		const result = replaceFunc(removed, regExp);
 		if (result !== undefined) {
 			removed = result;

--- a/test/features.test.ts
+++ b/test/features.test.ts
@@ -79,7 +79,7 @@ describe("apply heading", () => {
 
 	describe("With Auto Indent", () => {
 		const autoIndentSettings: Partial<HeadingShifterSettings> = {
-			autoIndentBulletedHeader: true,
+			syncHeadingsAndListsLevel: true,
 		};
 
 		test("list to 0", () => {


### PR DESCRIPTION
-  #40 
    - [fix: dont outdent during sync with list](https://github.com/k4a-l/obsidian-heading-shifter/commit/7405f3a496930074c35895d817a2f6e45b3173ee)
- part of #41 
    - [fix: remove unnecessary console.log](https://github.com/k4a-l/obsidian-heading-shifter/commit/4a2f716815b4f18e6563f60456a1ef5a6fe2891a)
    - [fix: header->heading (changed setting prop name)](https://github.com/k4a-l/obsidian-heading-shifter/pull/42/commits/6ee44615644438ce18db3bb3b580ed55c0f35590)
- others
    - [fix: remove biggining chars are not removed when 1 or more indents](https://github.com/k4a-l/obsidian-heading-shifter/commit/5bfb02f8a3eb34a49fa351e5886bbc5515f1b823)


If there are any others, add them as needed.
If there don't seem to be any, release it in about 12 hours.