### PR TITLE
fix: fix heading level misjudgment when line number is 0

### DIFF
--- a/src/features/insertHeading/operation.ts
+++ b/src/features/insertHeading/operation.ts
@@ -5,7 +5,7 @@ import type { HeadingShifterSettings } from "settings";
 import type { EditorOperation } from "types/editorOperation";
 import type { StopPropagation } from "types/type";
 import { composeLineChanges } from "utils/editorChange";
-import { checkHeading, getPreviousHeading } from "utils/markdown";
+import { getPreviousHeadingLevel } from "utils/markdown";
 
 export class InsertHeadingAtCurrentLevel implements EditorOperation {
 	settings: HeadingShifterSettings;
@@ -15,14 +15,7 @@ export class InsertHeadingAtCurrentLevel implements EditorOperation {
 
 	editorCallback = (editor: Editor): StopPropagation => {
 		const cursorLine = editor.getCursor("from").line;
-		const lastHeadingLine = getPreviousHeading(editor, cursorLine);
-
-		// current heading level == most recently added heading
-		// 0 if no heading exists yet
-		const headingLevel =
-			lastHeadingLine !== undefined
-				? checkHeading(editor.getLine(lastHeadingLine))
-				: 0;
+		const headingLevel = getPreviousHeadingLevel(editor, cursorLine);
 		const targetHeadingLevel = headingLevel;
 
 		const headingChanges = composeLineChanges(editor, [cursorLine], (chunk) =>
@@ -62,13 +55,7 @@ export class InsertHeadingAtDeeperLevel implements EditorOperation {
 
 	editorCallback = (editor: Editor): StopPropagation => {
 		const cursorLine = editor.getCursor("from").line;
-		const lastHeadingLine = getPreviousHeading(editor, cursorLine);
-
-		// current heading level == most recently added heading
-		// 0 if no heading exists yet
-		const headingLevel = lastHeadingLine !== undefined
-			? checkHeading(editor.getLine(lastHeadingLine))
-			: 0;
+		const headingLevel = getPreviousHeadingLevel(editor, cursorLine);
 
 		if (headingLevel + 1 > 6) {
 			new Notice("Cannot increase (contains more than heading 6)");
@@ -116,14 +103,7 @@ export class InsertHeadingAtHigherLevel implements EditorOperation {
 
 	editorCallback = (editor: Editor): StopPropagation => {
 		const cursorLine = editor.getCursor("from").line;
-		const lastHeadingLine = getPreviousHeading(editor, cursorLine);
-
-		// current heading level == most recently added heading
-		// 0 if no heading exists yet
-		const headingLevel = lastHeadingLine !== undefined
-			? checkHeading(editor.getLine(lastHeadingLine))
-			: 0;
-
+		const headingLevel = getPreviousHeadingLevel(editor, cursorLine);
 		const targetHeadingLevel = headingLevel - 1;
 
 		const headingChanges = composeLineChanges(

--- a/src/features/insertHeading/operation.ts
+++ b/src/features/insertHeading/operation.ts
@@ -66,7 +66,7 @@ export class InsertHeadingAtDeeperLevel implements EditorOperation {
 
 		// current heading level == most recently added heading
 		// 0 if no heading exists yet
-		const headingLevel = lastHeadingLine
+		const headingLevel = lastHeadingLine !== undefined
 			? checkHeading(editor.getLine(lastHeadingLine))
 			: 0;
 
@@ -120,7 +120,7 @@ export class InsertHeadingAtHigherLevel implements EditorOperation {
 
 		// current heading level == most recently added heading
 		// 0 if no heading exists yet
-		const headingLevel = lastHeadingLine
+		const headingLevel = lastHeadingLine !== undefined
 			? checkHeading(editor.getLine(lastHeadingLine))
 			: 0;
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -89,6 +89,17 @@ export const getPreviousHeading = (
 	return undefined;
 };
 
+export const getPreviousHeadingLevel = (
+	editor: {
+		getLine: (number: number) => string;
+	},
+	from: number,
+): number => {
+	const prevHeadingLine = getPreviousHeading(editor, from);
+	if (prevHeadingLine === undefined) return 0;
+	return checkHeading(editor.getLine(prevHeadingLine));
+};
+
 /** Returns the result of the substitution only when the substitution is performed, otherwise undefined */
 const replaceFunc = (str: string, regExp: RegExp): string | undefined => {
 	try {


### PR DESCRIPTION
Fix a bug where `InsertHeadingAtDeeperLevel` and `InsertHeadingAtHigherLevel` incorrectly determine the heading level when the previous heading is on line 0 (the first line of the document).

The same logic had already been applied to InsertHeadingAtCurrentLevel before this fix.